### PR TITLE
adding a previous version of the newrelic gem to avoid exceptions on …

### DIFF
--- a/Gemfile.d/launchcode.rb
+++ b/Gemfile.d/launchcode.rb
@@ -1,0 +1,1 @@
+gem 'newrelic_rpm', '3.12.0.288'


### PR DESCRIPTION
It appears that if we use an older version of the new relic gem, we can get canvas and new relic to play together nicely.
