### PR TITLE
Adding newrelic gem back

### DIFF
--- a/Gemfile.d/launchcode.rb
+++ b/Gemfile.d/launchcode.rb
@@ -1,1 +1,2 @@
 
+gem 'newrelic_rpm'


### PR DESCRIPTION
New relic gem was removed during a migration that had issues. The newrelic gem was never added back. We actually want newrelic running in our Canvas rails apps because it gives us much more insight into the application.